### PR TITLE
Add links to download public/private keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In order to get tokens usable with Tesla's Fleet API, you will need to:
 - Obtain a domain name, if you don't already have one. (This needs to be a
   domain you completely control, not just a subdomain on a shared parent
   domain.)
-- Deploy this container so that Your domain registered above, or a subdomain of
+- Deploy this container so that your domain registered above, or a subdomain of
   it (e.g. `https://tesla.example.com`) points to it with ports 80 and 443
   exposed. Make sure you can access it over HTTPS with a valid certificate.
 - Register for a [developer account](https://developer.tesla.com) at Tesla
@@ -52,7 +52,9 @@ Configuration is read from environment variables:
 - ALLOWED_USERS is a comma- or semicolon-separated list of e-mail addresses for
   Tesla accounts allowed to obtain tokens. For example, `elon@tesla.com,
   alice@example.com`. (The "Profile Information" scope is used to check the
-  e-mail address of users who attempt to log in.)
+  e-mail address of users who attempt to log in.) The first user in the list is
+  also allowed to download the private key enrolled for sending commands to the
+  vehicles.
 - CLIENT_ID is your Tesla Client ID, provided after registering an application
   on the Developer portal.
 - CLIENT_SECRET is your Tesla Client Secret, provided after registering an

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -37,3 +37,19 @@ a {
     /* Add space between the text and the button */
   }
 }
+
+.conditional-links {
+  text-align: center;
+  font-size: 0.9em;
+  /* Adjust the text size as needed */
+}
+
+.link {
+  margin-right: 10px;
+  /* Add some space between the links */
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -48,7 +48,8 @@ router.get('/', async function (req, res, next) {
     //   - Refresh token if needed
     //   - Show token
 
-    if (ALLOWED_USERS.split(/[ ,;]+/).includes(req.session.user)) {
+    const allowed_users = ALLOWED_USERS.split(/[ ,;]+/);
+    if (allowed_users.includes(req.session.user)) {
       var db = res.app.locals.db;
       var userToken = await db.get(req.session.user);
 
@@ -66,7 +67,8 @@ router.get('/', async function (req, res, next) {
           user: req.session.user,
           access_token: userToken.access_token,
           refresh_token: userToken.refresh_token,
-          expiration: userToken.expiration
+          expiration: userToken.expiration,
+          showPrivateKey: req.session.user == allowed_users[0]
         });
       }
       else {

--- a/routes/tesla-cert.js
+++ b/routes/tesla-cert.js
@@ -31,17 +31,19 @@ async function readOrGenerateKeypair(mutex, wantPublic) {
     // Write the keypair to disk
     //
     // Caller will need to catch errors here
-    await fs.writeFile(pubkey_file, keypair.publicKey, 'utf-8');
-    await fs.writeFile(privkey_file, keypair.privateKey, 'utf-8');
+    await Promise.all([
+      fs.writeFile(pubkey_file, keypair.publicKey, 'utf-8'),
+      fs.writeFile(privkey_file, keypair.privateKey, 'utf-8')
+    ]);
     result = wantPublic ? keypair.publicKey : keypair.privateKey;
   });
   return result;
 }
 
-/* Tesla callback from OAuth flow. */
+/* Tesla callback from Register flow. */
 router.get('/com.tesla.3p.public-key.pem', async function (req, res, next) {
 
-  // If successfully saved, return public key in PEM format
+  // Retrieve and return public key
   try {
     var pubkey = await readOrGenerateKeypair(req.app.locals.keyMutex, true);
     return res.

--- a/routes/tesla-cert.js
+++ b/routes/tesla-cert.js
@@ -2,20 +2,16 @@ var express = require('express');
 var router = express.Router();
 var fs = require("fs/promises");
 var crypto = require("crypto");
+const ALLOWED_USERS = process.env.ALLOWED_USERS || "";
+const pubkey_file = "/data/keypair_pub.pem";
+const privkey_file = "/data/keypair_priv.pem";
 
-
-/* Tesla callback from OAuth flow. */
-router.get('/com.tesla.3p.public-key.pem', async function(req, res, next) {
-  await req.app.locals.keyMutex.runExclusive(async () => {
-    // - If cert doesn't exist, generate EC keypair using the secp256r1 curve
-    //   (prime256v1) and write to disk
-    const pubkey_file = "/data/keypair_pub.pem";
-    const privkey_file = "/data/keypair_priv.pem";
-
+async function readOrGenerateKeypair(mutex, wantPublic) {
+  var result;
+  await mutex.runExclusive(async () => {
     try {
-      // Try to read the public key file
-      const pubkey = await fs.readFile(pubkey_file);
-      res.send(pubkey);
+      // Try to read the requested key file
+      result = await fs.readFile(wantPublic ? pubkey_file : privkey_file, 'utf-8');
       return;
     } catch (error) { }
 
@@ -33,21 +29,56 @@ router.get('/com.tesla.3p.public-key.pem', async function(req, res, next) {
     });
 
     // Write the keypair to disk
-    try {
-      await fs.writeFile(pubkey_file, keypair.publicKey);
-      await fs.writeFile(privkey_file, keypair.privateKey);
+    //
+    // Caller will need to catch errors here
+    await fs.writeFile(pubkey_file, keypair.publicKey, 'utf-8');
+    await fs.writeFile(privkey_file, keypair.privateKey, 'utf-8');
+    result = wantPublic ? keypair.publicKey : keypair.privateKey;
+  });
+  return result;
+}
 
-      // If successfully saved, return public key in PEM format
-      res.send(keypair.publicKey);
+/* Tesla callback from OAuth flow. */
+router.get('/com.tesla.3p.public-key.pem', async function (req, res, next) {
+
+  // If successfully saved, return public key in PEM format
+  try {
+    var pubkey = await readOrGenerateKeypair(req.app.locals.keyMutex, true);
+    return res.
+      setHeader("content-type", "application/x-pem-file").
+      send(pubkey);
+  } catch (error) {
+    console.log(error);
+  }
+
+  // If failed, return 404
+  res.status(404);
+  res.send("Not Found");
+});
+
+router.get('/com.tesla.3p.private-key.pem', async function (req, res, next) {
+  if (req.session.user && ALLOWED_USERS.split(/[ ,;]+/)[0] == req.session.user) {
+    // Only the primary user is allowed to download the private key
+    try {
+      res.
+        setHeader("content-type", "application/x-pem-file").
+        send(await readOrGenerateKeypair(req.app.locals.keyMutex, false));
       return;
     } catch (error) {
       console.log(error);
     }
-
-    // If failed, return 404
-    res.status(404);
-    res.send("Not Found");
-  });
+  }
+  else if (req.session.user) {
+    res.status(403);
+    res.render("error", {
+      message: "Unauthorized",
+      error: `${req.session.user} not allowed to download private key.`
+    });
+    return;
+  }
+  else {
+    res.redirect(tesla.getAuthURL(req.session.id));
+  }
 });
 
 module.exports = router;

--- a/views/index.pug
+++ b/views/index.pug
@@ -54,3 +54,9 @@ block content
     label(for="expiration-time") Expiration Time:
     p#expiration-time=new Date(expiration * 1000).toLocaleString()
     p#formatted-expiration-time 
+
+  .conditional-links
+    a(href=".well-known/appspecific/com.tesla.3p.public-key.pem" class="link") Public Key
+
+    if showPrivateKey
+      a(href=".well-known/appspecific/com.tesla.3p.private-key.pem" class="link") Private Key


### PR DESCRIPTION
All users can download the public key; only the first configured user gets the private key as well, since they're probably the one setting up a command proxy et al.