### PR TITLE
Check and alert on various configuration/access errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,26 @@ app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
+
+const DOMAIN = process.env.DOMAIN;
+app.use((req, res, next) => {
+  if( !DOMAIN ) {
+    return res.
+      status(500).
+      render("error", {
+        message: "Configuration error",
+        error: "No DOMAIN environment variable set"
+      });
+  }
+  // Redirect to correct hostname with HTTPS
+  else if (req.hostname !== DOMAIN) {
+    return res.redirect(301, `https://${DOMAIN}${req.originalUrl}`);
+  }
+  else {
+    return next();
+  }
+});
+
 app.use(express.static(path.join(__dirname, 'public')));
 
 var sessionKey;

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,15 +3,26 @@ var router = express.Router();
 var tesla = require('../tesla-tokens.js');
 const ALLOWED_USERS = process.env.ALLOWED_USERS || "";
 const CLIENT_ID = process.env.CLIENT_ID;
+const CLIENT_SECRET = process.env.CLIENT_SECRET;
 
 /* GET home page. */
 router.get('/', async function (req, res, next) {
-  if( !CLIENT_ID ) {
+  if (!ALLOWED_USERS) {
+    return res.
+      status(500).
+      render("error", {
+        title: "Configuration error",
+        message: "Configuration error",
+        error: "No users allowed to use this service; set ALLOWED_USERS."
+      });
+  }
+
+  if( !CLIENT_ID || !CLIENT_SECRET ) {
     res.status(200);
     res.render("error", {
       title: "Container is running",
       message: "Up and running",
-      error: "Need the Tesla client ID to do anything useful, but make sure TLS works here first."
+      error: "Need the Tesla client ID and secret to do anything useful, but make sure TLS works here first."
     });
     return;
   }
@@ -62,7 +73,7 @@ router.get('/', async function (req, res, next) {
         }
         res.render('index', {
           CLIENT_ID: CLIENT_ID,
-          title: 'Tesla Token Proxy',
+          title: 'Fleet API Tokens',
           user: req.session.user,
           access_token: userToken.access_token,
           refresh_token: userToken.refresh_token,


### PR DESCRIPTION
Adds error conditions and fixes for various easy configuration mistakes:

- Fail early and show error page if `DOMAIN` not set
- Redirect if accessing via a different host than `DOMAIN` (e.g. by IP address or localhost), since those will break the OAuth/session state check
- Fail before OAuth if no users are authorized
- Check that both `CLIENT_ID` and `CLIENT_SECRET` are present before attempting to register